### PR TITLE
Add option "wait"

### DIFF
--- a/jquery.equalheights.js
+++ b/jquery.equalheights.js
@@ -14,7 +14,7 @@
         var maxHeight = 0,
             options = options || {},
             $this = $(this),
-            equalHeight = function() {
+            equalHeightsFn = function() {
                 var height = $(this).innerHeight();
     
                 if ( height > maxHeight ) { maxHeight = height; }
@@ -26,11 +26,11 @@
                     clearInverval(loop);
                     return $this.css('height', maxHeight);
                 }
-                $this.each(equalHeights);
+                $this.each(equalHeightsFn);
             }, 100);
         }
 
-        $this.each(equalHeights);
+        $this.each(equalHeightsFn);
 
         return $this.css('height', maxHeight);
     };

--- a/jquery.equalheights.js
+++ b/jquery.equalheights.js
@@ -10,15 +10,27 @@
  */
 (function($) {
 
-    $.fn.equalHeights = function() {
+    $.fn.equalHeights = function(options) {
         var maxHeight = 0,
-            $this = $(this);
+            options = options || {},
+            $this = $(this),
+            equalHeight = function() {
+                var height = $(this).innerHeight();
+    
+                if ( height > maxHeight ) { maxHeight = height; }
+            };
 
-        $this.each( function() {
-            var height = $(this).innerHeight();
+        if(options.wait) {
+            var loop = setInveral(function() {
+                if(maxHeight > 0) {
+                    clearInverval(loop);
+                    return $this.css('height', maxHeight);
+                }
+                $this.each(equalHeights);
+            }, 100);
+        }
 
-            if ( height > maxHeight ) { maxHeight = height; }
-        });
+        $this.each(equalHeights);
 
         return $this.css('height', maxHeight);
     };

--- a/jquery.equalheights.js
+++ b/jquery.equalheights.js
@@ -12,27 +12,27 @@
 
     $.fn.equalHeights = function(options) {
         var maxHeight = 0,
-            options = options || {},
             $this = $(this),
             equalHeightsFn = function() {
                 var height = $(this).innerHeight();
     
                 if ( height > maxHeight ) { maxHeight = height; }
             };
+        options = options || {};
+
+        $this.each(equalHeightsFn);
 
         if(options.wait) {
-            var loop = setInveral(function() {
+            var loop = setInterval(function() {
                 if(maxHeight > 0) {
-                    clearInverval(loop);
+                    clearInterval(loop);
                     return $this.css('height', maxHeight);
                 }
                 $this.each(equalHeightsFn);
             }, 100);
+        } else {
+            return $this.css('height', maxHeight);
         }
-
-        $this.each(equalHeightsFn);
-
-        return $this.css('height', maxHeight);
     };
 
     // auto-initialize plugin


### PR DESCRIPTION
This would be implemented by someone running `$(".equal-heights").equalHeights({ wait: true });`
Basically, it keeps running equalHeights until the maxHeight is greater than 0. It's really annoying when equalHeights is implemented at a time before the content has loaded and it sets the elements to be a height of 0px. This prevents this only when specifically requested by the user. Also, this opens the door to have other potential options in the future.