### PR TITLE
fix(bower.json): fix main path name

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,6 +6,6 @@
   	"jquery": ">=1.7"
   },
   "main": [
-    "jquery.equalHeights.js"
+    "jquery.equalheights.js"
   ]
 }


### PR DESCRIPTION
Fix main path name. Main path name did not correspond to file name (jquery.equalheights.js != jquery.equalHeights.js). This causes problems in relation to grunt-wiredep.