### PR TITLE
Adjust div height based on row

### DIFF
--- a/jquery.equalheights.js
+++ b/jquery.equalheights.js
@@ -11,16 +11,35 @@
 (function($) {
 
     $.fn.equalHeights = function() {
-        var maxHeight = 0,
-            $this = $(this);
+        var $this = $(this),
+            curTallest = 0,
+            curRowBegin = 0,
+            rowLength = [],
+            element,
+            topPos = 0;
 
-        $this.each( function() {
-            var height = $(this).innerHeight();
-
-            if ( height > maxHeight ) { maxHeight = height; }
+        return $this.each( function() {
+            element = $(this);
+            // if element is on same row or not
+            topPos = element.offset().top;
+            runFor = function() {
+                for(curDiv = 0; curDiv < rowLength.length; curDiv++) {
+                    rowLength[curDiv].css('min-height', curTallest);
+                }
+            };
+            if(curRowBegin !== topPos) {
+                runFor();
+                rowLength.length = 0;
+                curRowBegin = topPos;
+                curTallest = element.outerHeight();
+                rowLength.push(element);
+            } else {
+                rowLength.push(element);
+                curTallest = (curTallest < element.outerHeight()) ? (element.outerHeight()) : (curTallest);
+            }
+            runFor();
         });
 
-        return $this.css('height', maxHeight);
     };
 
     // auto-initialize plugin

--- a/jquery.equalheights.min.js
+++ b/jquery.equalheights.min.js
@@ -8,4 +8,4 @@
  *
  * @version 1.5.1
  */
-!function(a){a.fn.equalHeights=function(){var b=0,c=a(this);return c.each(function(){var c=a(this).innerHeight();c>b&&(b=c)}),c.css("height",b)},a("[data-equal]").each(function(){var b=a(this),c=b.data("equal");b.find(c).equalHeights()})}(jQuery);
+!function(a){a.fn.equalHeights=function(){var b,c=a(this),d=0,e=0,f=[],g=0;return c.each(function(){b=a(this),g=b.offset().top,runFor=function(){for(curDiv=0;curDiv<f.length;curDiv++)f[curDiv].css("min-height",d)},e!==g?(runFor(),f.length=0,e=g,d=b.outerHeight(),f.push(b)):(f.push(b),d=d<b.outerHeight()?b.outerHeight():d),runFor()})},a("[data-equal]").each(function(){var b=a(this),c=b.data("equal");b.find(c).equalHeights()})}(jQuery);


### PR DESCRIPTION
Noticed that all divs were getting the tallest div no matter what row, wrote this so that it gets the tallest div in that row only. This could also be implemented into a user setting, so that if they want all divs the same height no matter what they could set it.

Can also be made responsive, simply call the function on a window resize:

``` jQuery
$(window).resize(function () {
  $('#equalheight div').equalHeights();
});
```
